### PR TITLE
[#15] .fromJson() 리팩토링 (KakaoDetail.class)

### DIFF
--- a/src/main/kotlin/team/guin/monolithic/application/security/filter/JWTAuthenticationFilter.kt
+++ b/src/main/kotlin/team/guin/monolithic/application/security/filter/JWTAuthenticationFilter.kt
@@ -13,6 +13,7 @@ import team.guin.monolithic.infrastructure.kakao.service.KakaoApiService
 import team.guin.monolithic.application.security.config.SecurityProperties
 import team.guin.monolithic.application.security.service.TokenProvider
 import team.guin.monolithic.application.user.dto.ReqLoginDTO
+import team.guin.monolithic.infrastructure.kakao.dto.KakaoDetail
 import java.io.IOException
 import javax.servlet.FilterChain
 import javax.servlet.ServletException
@@ -37,10 +38,10 @@ class JWTAuthenticationFilter(
             val creds = mapper.readValue<ReqLoginDTO>(req.inputStream)
 
             val jsonData = kakaoApiService.getUserInfoFromKakaoAccessToken(creds.kakaoAccessToken)
-            val (id, properties, kakao_account) = kakaoApiService.convertKakaoUserInfoDTO(jsonData)
+            val kakaoDetail = KakaoDetail.from(jsonData)
             authManager.authenticate(
                 UsernamePasswordAuthenticationToken(
-                    kakao_account["email"],
+                    kakaoDetail.kakao_account["email"],
                     "",
                     ArrayList(),
                 ),

--- a/src/main/kotlin/team/guin/monolithic/application/user/dto/UserDTO.kt
+++ b/src/main/kotlin/team/guin/monolithic/application/user/dto/UserDTO.kt
@@ -1,4 +1,4 @@
 package team.guin.monolithic.application.user.dto
 
 data class ReqLoginDTO(var kakaoAccessToken: String)
-data class ReqJoinUserDTO(val email: String, val nickName: String, val imageId: String)
+data class ReqJoinUserDTO(val email: String, val nickname: String, val imageId: String)

--- a/src/main/kotlin/team/guin/monolithic/infrastructure/kakao/dto/KakaoDetail.kt
+++ b/src/main/kotlin/team/guin/monolithic/infrastructure/kakao/dto/KakaoDetail.kt
@@ -1,18 +1,18 @@
 package team.guin.monolithic.infrastructure.kakao.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class KakaoDetail(
-    val id: String,
+class KakaoDetail(
     val properties: Map<String, Any> = emptyMap(),
     val kakao_account: Map<String, Any> = emptyMap(),
 ) {
-    /* fun convertKakaoUserInfoDTO(jsonData: String): KakaoDetail {
-         val mapper = jacksonObjectMapper()
-         val kakaoDetail = mapper.readValue(jsonData, KakaoDetail::class.java)
-         return kakaoDetail
-     }*/
+    companion object {
+        fun from(jsonData: String): KakaoDetail {
+            val mapper = jacksonObjectMapper()
+            val kakaoDetail = mapper.readValue(jsonData, KakaoDetail::class.java)
+            return kakaoDetail
+        }
+    }
 }
-
-//data class KakaoProperties(val nickName:String,val profileImage: String, val thumbnailImage: String)

--- a/src/main/kotlin/team/guin/monolithic/infrastructure/kakao/service/KakaoApiService.kt
+++ b/src/main/kotlin/team/guin/monolithic/infrastructure/kakao/service/KakaoApiService.kt
@@ -1,10 +1,8 @@
 package team.guin.monolithic.infrastructure.kakao.service
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import team.guin.monolithic.infrastructure.kakao.dto.KakaoDetail
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
@@ -15,15 +13,9 @@ import javax.validation.constraints.Size
 @Component
 @ConfigurationProperties(prefix = "kakao")
 class KakaoApiService {
-
     @field:NotBlank
     @field:Size(min = 64)
     var kakaoUrl = ""
-    fun convertKakaoUserInfoDTO(jsonData: String): KakaoDetail {
-        val mapper = jacksonObjectMapper()
-        val kakaoDetail = mapper.readValue(jsonData, KakaoDetail::class.java)
-        return kakaoDetail
-    }
 
     fun getUserInfoFromKakaoAccessToken(kakaoAccessToken: String): String {
         val url = URL(kakaoUrl + "v2/user/me")


### PR DESCRIPTION
- 카카오 측에서 받은 유저 정보를 매핑(Json->Object)하는 메서드를 DTO에 위임하였습니다.
  - Service 클래스에 있을 경우 SRP 원칙을 위반하여 이동하였습니다.
  
- KakaoDetail에 사용하지 않는 id 변수를 삭제하였습니다. 
  - 사용하지 않는 변수를 통해 혼란을 야기 할 수 있으며 효율적이지 않습니다.