### PR TITLE
[#45]  회원정보 수정 PUT /account

### DIFF
--- a/api/src/main/kotlin/team/guin/account/AccountApiController.kt
+++ b/api/src/main/kotlin/team/guin/account/AccountApiController.kt
@@ -1,11 +1,14 @@
 package team.guin.account
 
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.guin.account.dto.AccountDetail
 import team.guin.account.dto.AccountJoinRequest
+import team.guin.account.dto.AccountUpdateRequest
 import team.guin.common.CommonResponse
 
 @RestController
@@ -18,5 +21,11 @@ class AccountApiController(
         val account = accountApiService.join(accountJoinRequest.email, accountJoinRequest.nickname, accountJoinRequest.imageId)
         val detail = AccountDetail(account.email, account.nickname, account.imageId)
         return CommonResponse.okWithDetail(detail)
+    }
+
+    @PutMapping("{id}")
+    fun update(@PathVariable id: Long, @RequestBody accountDetail: AccountUpdateRequest): CommonResponse<AccountDetail> {
+        val account = accountApiService.updateInfo(id, accountDetail.email, accountDetail.nickname, accountDetail.imageId)
+        return CommonResponse.okWithDetail(AccountDetail(account.email, account.nickname, account.imageId))
     }
 }

--- a/api/src/main/kotlin/team/guin/account/AccountApiController.kt
+++ b/api/src/main/kotlin/team/guin/account/AccountApiController.kt
@@ -24,8 +24,8 @@ class AccountApiController(
     }
 
     @PutMapping("{id}")
-    fun update(@PathVariable id: Long, @RequestBody accountDetail: AccountUpdateRequest): CommonResponse<AccountDetail> {
-        val account = accountApiService.updateInfo(id, accountDetail.email, accountDetail.nickname, accountDetail.imageId)
+    fun update(@PathVariable id: Long, @RequestBody accountUpdateRequest: AccountUpdateRequest): CommonResponse<AccountDetail> {
+        val account = accountApiService.updateInfo(id, accountUpdateRequest.nickname, accountUpdateRequest.imageId)
         return CommonResponse.okWithDetail(AccountDetail(account.email, account.nickname, account.imageId))
     }
 }

--- a/api/src/main/kotlin/team/guin/account/AccountApiRepository.kt
+++ b/api/src/main/kotlin/team/guin/account/AccountApiRepository.kt
@@ -1,10 +1,10 @@
 package team.guin.account
 
-import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import team.guin.domain.account.Account
+import team.guin.domain.baseentity.BaseRepository
 
 @Repository
-interface AccountApiRepository : JpaRepository<Account, Long> {
+interface AccountApiRepository : BaseRepository<Account, Long> {
     fun findByEmail(email: String): Account?
 }

--- a/api/src/main/kotlin/team/guin/account/AccountApiService.kt
+++ b/api/src/main/kotlin/team/guin/account/AccountApiService.kt
@@ -17,9 +17,9 @@ class AccountApiService(
     }
 
     @Transactional
-    fun updateInfo(id: Long, email: String, nickname: String, imageId: String): Account {
+    fun updateInfo(id: Long, nickname: String, imageId: String): Account {
         val account = this.findByAccountId(id)
-        account.updateInfo(email, nickname, imageId)
+        account.updateInfo(nickname, imageId)
         return account
     }
 

--- a/api/src/main/kotlin/team/guin/account/AccountApiService.kt
+++ b/api/src/main/kotlin/team/guin/account/AccountApiService.kt
@@ -6,11 +6,9 @@ import org.springframework.transaction.annotation.Transactional
 import team.guin.domain.account.Account
 
 @Service
-@Transactional(readOnly = true)
 class AccountApiService(
     private val accountApiRepository: AccountApiRepository,
 ) {
-    @Transactional
     fun join(email: String, nickname: String, imageId: String): Account {
         val account = Account.create(email, nickname, imageId)
         return accountApiRepository.save(account)
@@ -18,12 +16,12 @@ class AccountApiService(
 
     @Transactional
     fun updateInfo(id: Long, nickname: String, imageId: String): Account {
-        val account = this.findByAccountId(id)
+        val account = this.findById(id)
         account.updateInfo(nickname, imageId)
         return account
     }
 
-    private fun findByAccountId(id: Long): Account {
+    private fun findById(id: Long): Account {
         return accountApiRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("유저가 존재하지 않습니다.")
     }
 }

--- a/api/src/main/kotlin/team/guin/account/AccountApiService.kt
+++ b/api/src/main/kotlin/team/guin/account/AccountApiService.kt
@@ -2,17 +2,21 @@ package team.guin.account
 
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.guin.domain.account.Account
 
 @Service
+@Transactional(readOnly = true)
 class AccountApiService(
     private val accountApiRepository: AccountApiRepository,
 ) {
+    @Transactional
     fun join(email: String, nickname: String, imageId: String): Account {
         val account = Account.create(email, nickname, imageId)
         return accountApiRepository.save(account)
     }
 
+    @Transactional
     fun updateInfo(id: Long, email: String, nickname: String, imageId: String): Account {
         val account = this.findByAccountId(id)
         account.updateInfo(email, nickname, imageId)

--- a/api/src/main/kotlin/team/guin/account/AccountApiService.kt
+++ b/api/src/main/kotlin/team/guin/account/AccountApiService.kt
@@ -1,5 +1,6 @@
 package team.guin.account
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import team.guin.domain.account.Account
 
@@ -10,5 +11,15 @@ class AccountApiService(
     fun join(email: String, nickname: String, imageId: String): Account {
         val account = Account.create(email, nickname, imageId)
         return accountApiRepository.save(account)
+    }
+
+    fun updateInfo(id: Long, email: String, nickname: String, imageId: String): Account {
+        val account = this.findByAccountId(id)
+        account.updateInfo(email, nickname, imageId)
+        return account
+    }
+
+    private fun findByAccountId(id: Long): Account {
+        return accountApiRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("유저가 존재하지 않습니다.")
     }
 }

--- a/api/src/main/kotlin/team/guin/account/dto/AccountUpdateRequest.kt
+++ b/api/src/main/kotlin/team/guin/account/dto/AccountUpdateRequest.kt
@@ -1,3 +1,3 @@
 package team.guin.account.dto
 
-data class AccountUpdateRequest(val email: String, val nickname: String, val imageId: String)
+data class AccountUpdateRequest(val nickname: String, val imageId: String)

--- a/api/src/main/kotlin/team/guin/account/dto/AccountUpdateRequest.kt
+++ b/api/src/main/kotlin/team/guin/account/dto/AccountUpdateRequest.kt
@@ -1,0 +1,3 @@
+package team.guin.account.dto
+
+data class AccountUpdateRequest(val email: String, val nickname: String, val imageId: String)

--- a/api/src/test/kotlin/team/guin/account/AccountApiRepositoryTests.kt
+++ b/api/src/test/kotlin/team/guin/account/AccountApiRepositoryTests.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
 import team.guin.domain.account.Account
 import team.guin.domain.account.enumeration.AccountRoles
 
@@ -42,6 +43,36 @@ class AccountApiRepositoryTests(
             withContext(Dispatchers.IO) {
                 accountApiRepository.findByEmail(targetEmail)
             } shouldBe null
+        }
+    }
+    "findByIdOrNull" - {
+        "해당하는 id가 없을 경우 널값을 반환합니다" - {
+            // given
+            val id: Long = -1
+
+            // when/then
+            withContext(Dispatchers.IO) {
+                accountApiRepository.findByIdOrNull(id) ?: null
+            } shouldBe null
+        }
+        "해당하는 id가 있을경우 account 반환합니다." - {
+            // given
+            val fromCode = AccountRoles.fromCode("USER")
+            val account = Account.create("a@a.com", "nickname", "imageId", fromCode)
+            withContext(Dispatchers.IO) {
+                accountApiRepository.save(account)
+            }
+
+            // when
+            val result =
+                withContext(Dispatchers.IO) {
+                    accountApiRepository.findByIdOrNull(account.id) ?: null
+                }
+
+            // then
+            result?.nickname shouldBe account.nickname
+            result?.imageId shouldBe account.imageId
+            result?.email shouldBe account.email
         }
     }
 })

--- a/api/src/test/kotlin/team/guin/account/AccountApiRepositoryTests.kt
+++ b/api/src/test/kotlin/team/guin/account/AccountApiRepositoryTests.kt
@@ -52,7 +52,7 @@ class AccountApiRepositoryTests(
 
             // when
             val result = withContext(Dispatchers.IO) {
-                accountApiRepository.findByIdOrNull(id) ?: null
+                accountApiRepository.findByIdOrNull(id)
             }
 
             // then
@@ -67,7 +67,7 @@ class AccountApiRepositoryTests(
             // when
             val result =
                 withContext(Dispatchers.IO) {
-                    accountApiRepository.findByIdOrNull(account.id) ?: null
+                    accountApiRepository.findByIdOrNull(account.id)
                 }
 
             // then

--- a/api/src/test/kotlin/team/guin/account/AccountApiRepositoryTests.kt
+++ b/api/src/test/kotlin/team/guin/account/AccountApiRepositoryTests.kt
@@ -46,22 +46,23 @@ class AccountApiRepositoryTests(
         }
     }
     "findByIdOrNull" - {
-        "해당하는 id가 없을 경우 널값을 반환합니다" - {
+        "해당하는 id가 없을 경우 널값을 반환한다." - {
             // given
             val id: Long = -1
 
-            // when/then
-            withContext(Dispatchers.IO) {
+            // when
+            val result = withContext(Dispatchers.IO) {
                 accountApiRepository.findByIdOrNull(id) ?: null
-            } shouldBe null
+            }
+
+            // then
+            result shouldBe null
         }
-        "해당하는 id가 있을경우 account 반환합니다." - {
+        "해당하는 id가 있을경우 account 반환한다." - {
             // given
             val fromCode = AccountRoles.fromCode("USER")
             val account = Account.create("a@a.com", "nickname", "imageId", fromCode)
-            withContext(Dispatchers.IO) {
-                accountApiRepository.save(account)
-            }
+            accountApiRepository.save(account)
 
             // when
             val result =

--- a/api/src/test/kotlin/team/guin/account/AccountApiServiceTests.kt
+++ b/api/src/test/kotlin/team/guin/account/AccountApiServiceTests.kt
@@ -43,24 +43,26 @@ class AccountApiServiceTests(
             val nickname = "nickname"
             val imageId = "https://imugr.com/example"
             val savedAccount = accountApiRepository.save(Account(email, nickname, imageId, AccountRoles.USER))
-
-            // when
             val changeNickname = "changeNickname"
             val changeImageId = "https://imugr.com/change"
+
+            // when
             val updatedAccount =
                 accountApiService.updateInfo(savedAccount.id, changeNickname, changeImageId)
 
             // then
-            updatedAccount.email shouldBe email
-            updatedAccount.imageId shouldBe changeImageId
-            updatedAccount.nickname shouldBe changeNickname
+            val findUpdateAccount = accountApiRepository.findById(updatedAccount.id).get()
+            findUpdateAccount.email shouldBe email
+            findUpdateAccount.imageId shouldBe changeImageId
+            findUpdateAccount.nickname shouldBe changeNickname
         }
 
-        "해당하는 AccountId 존재하지 않을경우 예외가 발생한다." - {
+        "해당하는 Id 존재하지 않을경우 예외가 발생한다." - {
             // given
             val nickname = "nickname"
             val imageId = "https://imugr.com/example"
-            // && when
+
+            // when
             val exception =
                 shouldThrow<IllegalArgumentException> {
                     accountApiService.updateInfo(

--- a/api/src/test/kotlin/team/guin/account/AccountApiServiceTests.kt
+++ b/api/src/test/kotlin/team/guin/account/AccountApiServiceTests.kt
@@ -59,6 +59,7 @@ class AccountApiServiceTests(
 
         "해당하는 Id 존재하지 않을경우 예외가 발생한다." - {
             // given
+            val id: Long = -1
             val nickname = "nickname"
             val imageId = "https://imugr.com/example"
 
@@ -66,9 +67,9 @@ class AccountApiServiceTests(
             val exception =
                 shouldThrow<IllegalArgumentException> {
                     accountApiService.updateInfo(
-                        -1,
-                        nickname,
-                        imageId,
+                        id,
+                        "nickname",
+                        "https://imugr.com/example",
                     )
                 }
 

--- a/api/src/test/kotlin/team/guin/account/AccountApiServiceTests.kt
+++ b/api/src/test/kotlin/team/guin/account/AccountApiServiceTests.kt
@@ -45,21 +45,19 @@ class AccountApiServiceTests(
             val savedAccount = accountApiRepository.save(Account(email, nickname, imageId, AccountRoles.USER))
 
             // when
-            val changeEmail = "test@a.com"
             val changeNickname = "changeNickname"
             val changeImageId = "https://imugr.com/change"
             val updatedAccount =
-                accountApiService.updateInfo(savedAccount.id, changeEmail, changeNickname, changeImageId)
+                accountApiService.updateInfo(savedAccount.id, changeNickname, changeImageId)
 
             // then
-            updatedAccount.email shouldBe changeEmail
+            updatedAccount.email shouldBe email
             updatedAccount.imageId shouldBe changeImageId
             updatedAccount.nickname shouldBe changeNickname
         }
 
         "해당하는 AccountId 존재하지 않을경우 예외가 발생한다." - {
             // given
-            val email = "a@a.com"
             val nickname = "nickname"
             val imageId = "https://imugr.com/example"
             // && when
@@ -67,7 +65,6 @@ class AccountApiServiceTests(
                 shouldThrow<IllegalArgumentException> {
                     accountApiService.updateInfo(
                         -1,
-                        email,
                         nickname,
                         imageId,
                     )

--- a/api/src/test/kotlin/team/guin/account/AccountApiServiceTests.kt
+++ b/api/src/test/kotlin/team/guin/account/AccountApiServiceTests.kt
@@ -1,10 +1,13 @@
 package team.guin.account
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.springframework.boot.test.context.SpringBootTest
+import team.guin.domain.account.Account
+import team.guin.domain.account.enumeration.AccountRoles
 
 @SpringBootTest
 class AccountApiServiceTests(
@@ -23,7 +26,7 @@ class AccountApiServiceTests(
 
             // then
             withContext(Dispatchers.IO) {
-                val optAccountEntity = accountApiRepository.findById(account.userId)
+                val optAccountEntity = accountApiRepository.findById(account.id)
                 optAccountEntity.isEmpty shouldBe false
 
                 val accountEntity = optAccountEntity.get()
@@ -31,6 +34,47 @@ class AccountApiServiceTests(
                 accountEntity.nickname shouldBe nickname
                 accountEntity.imageId shouldBe imageId
             }
+        }
+    }
+    "updateInfo" - {
+        "회원이 정보를 변경하면 정보를 업데이트 한다." - {
+            // given
+            val email = "a@a.com"
+            val nickname = "nickname"
+            val imageId = "https://imugr.com/example"
+            val savedAccount = accountApiRepository.save(Account(email, nickname, imageId, AccountRoles.USER))
+
+            // when
+            val changeEmail = "test@a.com"
+            val changeNickname = "changeNickname"
+            val changeImageId = "https://imugr.com/change"
+            val updatedAccount =
+                accountApiService.updateInfo(savedAccount.id, changeEmail, changeNickname, changeImageId)
+
+            // then
+            updatedAccount.email shouldBe changeEmail
+            updatedAccount.imageId shouldBe changeImageId
+            updatedAccount.nickname shouldBe changeNickname
+        }
+
+        "해당하는 AccountId 존재하지 않을경우 예외가 발생한다." - {
+            // given
+            val email = "a@a.com"
+            val nickname = "nickname"
+            val imageId = "https://imugr.com/example"
+            // && when
+            val exception =
+                shouldThrow<IllegalArgumentException> {
+                    accountApiService.updateInfo(
+                        -1,
+                        email,
+                        nickname,
+                        imageId,
+                    )
+                }
+
+            // then
+            exception.message shouldBe "유저가 존재하지 않습니다."
         }
     }
 })

--- a/domain/src/main/kotlin/team/guin/domain/account/Account.kt
+++ b/domain/src/main/kotlin/team/guin/domain/account/Account.kt
@@ -21,8 +21,7 @@ class Account(
     val accountRoles: AccountRoles,
 ) : BaseEntity() {
 
-    fun updateInfo(email: String, nickname: String, imageId: String) {
-        this.email = email
+    fun updateInfo(nickname: String, imageId: String) {
         this.nickname = nickname
         this.imageId = imageId
     }

--- a/domain/src/main/kotlin/team/guin/domain/account/Account.kt
+++ b/domain/src/main/kotlin/team/guin/domain/account/Account.kt
@@ -2,18 +2,13 @@ package team.guin.domain.account
 
 import team.guin.domain.account.enumeration.AccountRoles
 import team.guin.domain.account.enumeration.AccountRolesConverter
+import team.guin.domain.baseentity.BaseEntity
 import javax.persistence.Column
 import javax.persistence.Convert
 import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
-import javax.persistence.Id
 
 @Entity
 class Account(
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var userId: Long,
     @Column
     var email: String,
     @Column
@@ -24,12 +19,17 @@ class Account(
         converter = AccountRolesConverter::class,
     )
     val accountRoles: AccountRoles,
-) {
-    constructor() : this(0, "", "", "", AccountRoles.USER)
+) : BaseEntity() {
+
+    fun updateInfo(email: String, nickname: String, imageId: String) {
+        this.email = email
+        this.nickname = nickname
+        this.imageId = imageId
+    }
 
     companion object {
         fun create(email: String, nickname: String, imageId: String, accountRoles: AccountRoles = AccountRoles.USER): Account {
-            return Account(0, email, nickname, imageId, accountRoles)
+            return Account(email, nickname, imageId, accountRoles)
         }
     }
 }


### PR DESCRIPTION
#### resolve  #45 
- 진홍님이 작업한 Account Entity, Repository를 일부 수정했습니다.
- findByIdOrNull에 대해서 임시로 예외처리를 처리했습니다.
- AccountUpdateRequest DTO를 만들었습니다.
- Account Entity내에 updateInfo메서드를 만들어서 회원정보 수정을 수행합니다.
- 로그인이 구현이 안되어있어 임시로 PathVariable를 이용하였습니다.