### PR TITLE
[5-1] GlobalExceptionHandler/Resolver 기본 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,7 @@ project(":domain") {
         api("org.springframework.boot:spring-boot-starter-data-jpa")
         implementation("org.modelmapper:modelmapper:3.1.1")
         implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
+        implementation("org.springframework.boot:spring-boot-starter-web")
         testImplementation("io.kotest:kotest-runner-junit5:5.5.4")
         testImplementation("io.kotest:kotest-assertions-core:5.5.4")
         testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")

--- a/domain/src/main/kotlin/team/guin/domain/controller/GlobalExceptionHandler.kt
+++ b/domain/src/main/kotlin/team/guin/domain/controller/GlobalExceptionHandler.kt
@@ -1,0 +1,17 @@
+package team.guin.domain.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import team.guin.domain.exception.CommonException
+import team.guin.domain.exception.response.ExceptionResponse
+
+@RestControllerAdvice
+class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
+    @ExceptionHandler(value = [CommonException::class])
+    protected fun handleCommonException(e: CommonException): ResponseEntity<ExceptionResponse> {
+        val exceptionResponse = ExceptionResponse(e.exceptionCode)
+        return ResponseEntity(exceptionResponse, e.exceptionCode.status)
+    }
+}

--- a/domain/src/main/kotlin/team/guin/domain/exception/CommonException.kt
+++ b/domain/src/main/kotlin/team/guin/domain/exception/CommonException.kt
@@ -1,0 +1,5 @@
+package team.guin.domain.exception
+
+import java.lang.RuntimeException
+
+class CommonException(val exceptionCode: CommonExceptionCode) : RuntimeException()

--- a/domain/src/main/kotlin/team/guin/domain/exception/CommonExceptionCode.kt
+++ b/domain/src/main/kotlin/team/guin/domain/exception/CommonExceptionCode.kt
@@ -1,0 +1,10 @@
+package team.guin.domain.exception
+
+import org.springframework.http.HttpStatus
+
+enum class CommonExceptionCode(
+    val status: HttpStatus,
+    val message: String,
+) {
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다. 다시 입력해주세요."),
+}

--- a/domain/src/main/kotlin/team/guin/domain/exception/response/ExceptionResponse.kt
+++ b/domain/src/main/kotlin/team/guin/domain/exception/response/ExceptionResponse.kt
@@ -1,0 +1,8 @@
+package team.guin.domain.exception.response
+
+import team.guin.domain.exception.CommonExceptionCode
+import java.util.Date
+
+data class ExceptionResponse(val message: String, val timestamp: Date) {
+    constructor(exceptionCode: CommonExceptionCode) : this(exceptionCode.message, Date())
+}

--- a/domain/src/main/kotlin/team/guin/example/controller/ExampleDomainController.kt
+++ b/domain/src/main/kotlin/team/guin/example/controller/ExampleDomainController.kt
@@ -1,0 +1,14 @@
+package team.guin.example.controller
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team.guin.domain.exception.CommonException
+import team.guin.domain.exception.CommonExceptionCode
+
+@RestController
+@RequestMapping("/domain/example")
+class ExampleDomainController {
+    @GetMapping("/exception")
+    fun returnException(): CommonException = throw CommonException(CommonExceptionCode.DUPLICATE_EMAIL)
+}

--- a/domain/src/test/kotlin/team/guin/domain/controller/GlobalExceptionHandlerTest.kt
+++ b/domain/src/test/kotlin/team/guin/domain/controller/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,30 @@
+package team.guin.domain.controller
+
+import io.kotest.core.spec.style.FreeSpec
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestConstructor
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest
+@AutoConfigureMockMvc
+class GlobalExceptionHandlerTest(val mockMvc: MockMvc) : FreeSpec({
+    "Exception" - {
+        "테스트 이셉션 요청을 보내면 중복된 이메일 예외를 반환한다." {
+            mockMvc.perform(
+                get("/domain/example/exception"),
+            ).andExpect(
+                status().is4xxClientError,
+            ).andExpectAll(
+                jsonPath("\$.message").value("중복된 이메일입니다. 다시 입력해주세요."),
+            ).andDo(
+                MockMvcResultHandlers.print(),
+            )
+        }
+    }
+})

--- a/web-common/src/main/kotlin/team/guin/webcommon/exception/CommonException.kt
+++ b/web-common/src/main/kotlin/team/guin/webcommon/exception/CommonException.kt
@@ -1,0 +1,5 @@
+package team.guin.webcommon.exception
+
+import java.lang.RuntimeException
+
+class CommonException(val exceptionCode: CommonExceptionCode) : RuntimeException()

--- a/web-common/src/main/kotlin/team/guin/webcommon/exception/CommonExceptionCode.kt
+++ b/web-common/src/main/kotlin/team/guin/webcommon/exception/CommonExceptionCode.kt
@@ -1,0 +1,10 @@
+package team.guin.webcommon.exception
+
+import org.springframework.http.HttpStatus
+
+enum class CommonExceptionCode(
+    val status: HttpStatus,
+    val message: String,
+) {
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다. 다시 입력해주세요."),
+}

--- a/web-common/src/main/kotlin/team/guin/webcommon/exception/GlobalExceptionHandler.kt
+++ b/web-common/src/main/kotlin/team/guin/webcommon/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,16 @@
+package team.guin.webcommon.exception
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import team.guin.webcommon.exception.response.ExceptionResponse
+
+@RestControllerAdvice
+class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
+    @ExceptionHandler(value = [CommonException::class])
+    fun handleCommonException(e: CommonException): ResponseEntity<ExceptionResponse> {
+        val exceptionResponse = ExceptionResponse(e.exceptionCode)
+        return ResponseEntity(exceptionResponse, e.exceptionCode.status)
+    }
+}

--- a/web-common/src/main/kotlin/team/guin/webcommon/exception/example/ExampleExceptionController.kt
+++ b/web-common/src/main/kotlin/team/guin/webcommon/exception/example/ExampleExceptionController.kt
@@ -10,5 +10,5 @@ import team.guin.webcommon.exception.CommonExceptionCode
 @RequestMapping("/domain/example")
 class ExampleExceptionController {
     @GetMapping("/exception/duplicate")
-    fun returnException(): CommonException = throw CommonException(CommonExceptionCode.DUPLICATE_EMAIL)
+    fun returnDuplicateException(): CommonException = throw CommonException(CommonExceptionCode.DUPLICATE_EMAIL)
 }

--- a/web-common/src/main/kotlin/team/guin/webcommon/exception/example/ExampleExceptionController.kt
+++ b/web-common/src/main/kotlin/team/guin/webcommon/exception/example/ExampleExceptionController.kt
@@ -1,0 +1,14 @@
+package team.guin.webcommon.exception.example
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team.guin.webcommon.exception.CommonException
+import team.guin.webcommon.exception.CommonExceptionCode
+
+@RestController
+@RequestMapping("/domain/example")
+class ExampleExceptionController {
+    @GetMapping("/exception/duplicate")
+    fun returnException(): CommonException = throw CommonException(CommonExceptionCode.DUPLICATE_EMAIL)
+}

--- a/web-common/src/main/kotlin/team/guin/webcommon/exception/response/ExceptionResponse.kt
+++ b/web-common/src/main/kotlin/team/guin/webcommon/exception/response/ExceptionResponse.kt
@@ -1,0 +1,8 @@
+package team.guin.webcommon.exception.response
+
+import team.guin.webcommon.exception.CommonExceptionCode
+import java.util.Date
+
+data class ExceptionResponse(val message: String, val timestamp: Date) {
+    constructor(exceptionCode: CommonExceptionCode) : this(exceptionCode.message, Date())
+}

--- a/web-common/src/test/kotlin/team/guin/webcommon/exception/GlobalExceptionHandlerTest.kt
+++ b/web-common/src/test/kotlin/team/guin/webcommon/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,25 @@
+package team.guin.webcommon.exception
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
+import org.springframework.http.ResponseEntity
+
+class GlobalExceptionHandlerTest() : FreeSpec({
+    "handleCommonException" - {
+        "CommonException 발생하면 GlobalException 변경한다. " {
+            // given
+            val globalExceptionHandler = GlobalExceptionHandler()
+            val commonException = CommonException(CommonExceptionCode.DUPLICATE_EMAIL)
+
+            // when
+            val result = globalExceptionHandler.handleCommonException(commonException)
+
+            // then
+            result should beInstanceOf(ResponseEntity::class)
+            result.statusCode.is4xxClientError shouldBe true
+            result.body?.message shouldBe "중복된 이메일입니다. 다시 입력해주세요."
+        }
+    }
+})

--- a/web-common/src/test/kotlin/team/guin/webcommon/exception/GlobalExceptionHandlerTest.kt
+++ b/web-common/src/test/kotlin/team/guin/webcommon/exception/GlobalExceptionHandlerTest.kt
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity
 
 class GlobalExceptionHandlerTest() : FreeSpec({
     "handleCommonException" - {
-        "CommonException 발생하면 GlobalException 변경한다. " {
+        "중복된 이메일 CommonException 발생하면 GlobalException 포맷으로 변경한다. " {
             // given
             val globalExceptionHandler = GlobalExceptionHandler()
             val commonException = CommonException(CommonExceptionCode.DUPLICATE_EMAIL)


### PR DESCRIPTION
resolve #37 
GlobalExceptionHandler/Resolver 구현 및
컨트롤러단에서 발생하는 예외에 대한 공통응답 나오게끔
 ExampleException(안에 Enum필드 포함)까지

