### PR TITLE
[#35] Test Result Action이 모든 서브프로젝트의 테스트 결과를 잘 취합하는지 확인

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -55,6 +55,7 @@ jobs:
         if: ${{ always() }} # 테스트가 실패하여도 Report를 보기 위해 `always`로 설정
         with:
           files: '**/test-results/test/TEST-*.xml'
+          display-details: true
 
       - name: Cleanup Gradle cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,3 +107,22 @@ project(":web-common") {
         testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
     }
 }
+
+project(":test") {
+    tasks.getByName("bootJar") {
+        enabled = true
+    }
+
+    tasks.getByName("jar") {
+        enabled = false
+    }
+
+    dependencies {
+        implementation(project(":domain"))
+        implementation(project(":web-common"))
+        implementation("org.springframework.boot:spring-boot-starter-web")
+        testImplementation("io.kotest:kotest-runner-junit5:5.5.4")
+        testImplementation("io.kotest:kotest-assertions-core:5.5.4")
+        testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,4 +4,5 @@ include(
     "api",
     "domain",
     "web-common",
+    "test",
 )

--- a/test/src/main/kotlin/team/guin/TestApplication.kt
+++ b/test/src/main/kotlin/team/guin/TestApplication.kt
@@ -1,0 +1,11 @@
+package team.guin
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class TestApplication
+
+fun main(args: Array<String>) {
+    runApplication<TestApplication>(*args)
+}

--- a/test/src/test/kotlin/team/guin/ExampleTests.kt
+++ b/test/src/test/kotlin/team/guin/ExampleTests.kt
@@ -1,0 +1,11 @@
+package team.guin
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class ExampleTests {
+    @Test
+    fun contextLoads() {
+    }
+}


### PR DESCRIPTION
resolve #35 

## 취합 여부를 확인하게 된 배경

![image](https://user-images.githubusercontent.com/33937365/224698358-40d1f54d-fee6-4fa3-9f53-031eb24637c3.png)

`build/test-results/test/TEST-*.xml`
위의 기존 경로 설정으로는 CI가 제대로 동작하질 않았습니다.
싱글모듈 프로젝트를 전제로 한 경로 설정인데, 멀티모듈로 전환했기 때문입니다.

이를 해결하고자 사진과 같이 ** 키워드를 사용해봤는데 api에 대해서는 잘 취합됐습니다.
하지만 모든 서브프로젝트에 잘 적용되는지 여부는 확실하지 않아, 이번에 확인해봤습니다.

## 취합이 잘 되는 것을 확인함

### GitHub 공식 문서

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
위 GitHub 공식 문서에서

\*: Matches zero or more characters, but does not match the / character. For example, Octo\* matches Octocat.
_0개 이상의 문자들과 match됩니다. 하지만 '/' 문자에는 match되지 않습니다._

\*\*: Matches zero or more of any character.
_0개 이상의 문자들과 match됩니다._

위와 같이 설명돼있습니다.

이는 즉 
`**/test-results/test/TEST-*.xml`
** 부분에 /를 포함한 어떤 문자가 들어가도 match가 된다는 것이기에
api/build **/test-result/test/TEST-1.xml** 
domain/build **/test-result/test/TEST-1.xml**
blabla/build **/test-result/test/TEST-1.xml**

위와 같이 어느 서브프로젝트에서 빌드되든 xml 파일이 잘 매칭될 것입니다

### 실제로 간단하게 검증

혹시 모르니
임의로 서브프로젝트 생성해서 테스트 만들었을때, 만든 테스트 파일이 잘 취합되는지 직접 확인해봤습니다

**기존 main 코드에서 감지되는 테스트 파일의 개수**
<img width="1467" alt="SCR-20230313-sfpt" src="https://user-images.githubusercontent.com/33937365/224696214-c1847599-1d81-4589-b88e-2726a135b9cd.png">
사진과 같이 5개입니다
링크: https://github.com/9in-team/Backend/actions/runs/4404471166/jobs/7714116583

<img width="835" alt="image" src="https://user-images.githubusercontent.com/33937365/224703446-54690862-9c47-410a-9456-89e856f536a7.png">
위 테스트 파일 추가 후 감지되는 테스트 파일의 개수
<img width="1463" alt="SCR-20230313-sfwh" src="https://user-images.githubusercontent.com/33937365/224696439-bbb6e062-2549-41b1-9d14-ff8ec621a479.png">

사진과 같이 6개입니다

링크: https://github.com/9in-team/Backend/actions/runs/4404587433/jobs/7714391950

잘 취합됩니다.

## 참고
확인이 목적이라서 Merge는 하지 않고 Close할 예정입니다!