### PR TITLE
 BaseRepository -> JpaRepository로 변경

### DIFF
--- a/api/src/main/kotlin/team/guin/account/AccountApiRepository.kt
+++ b/api/src/main/kotlin/team/guin/account/AccountApiRepository.kt
@@ -1,10 +1,10 @@
 package team.guin.account
 
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import team.guin.domain.account.Account
-import team.guin.domain.baseentity.BaseRepository
 
 @Repository
-interface AccountApiRepository : BaseRepository<Account, Long> {
+interface AccountApiRepository : JpaRepository<Account, Long> {
     fun findByEmail(email: String): Account?
 }

--- a/api/src/main/kotlin/team/guin/example/ExampleRepository.kt
+++ b/api/src/main/kotlin/team/guin/example/ExampleRepository.kt
@@ -1,8 +1,8 @@
 package team.guin.example
 
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import team.guin.domain.baseentity.BaseRepository
 import team.guin.domain.example.Example
 
 @Repository
-interface ExampleRepository : BaseRepository<Example, Long>
+interface ExampleRepository : JpaRepository<Example, Long>

--- a/api/src/main/kotlin/team/guin/team/TeamApiRepository.kt
+++ b/api/src/main/kotlin/team/guin/team/TeamApiRepository.kt
@@ -1,8 +1,8 @@
 package team.guin.team
 
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import team.guin.domain.baseentity.BaseRepository
 import team.guin.domain.team.Team
 
 @Repository
-interface TeamApiRepository : BaseRepository<Team, Long>
+interface TeamApiRepository : JpaRepository<Team, Long>

--- a/domain/src/main/kotlin/team/guin/domain/baseentity/BaseRepository.kt
+++ b/domain/src/main/kotlin/team/guin/domain/baseentity/BaseRepository.kt
@@ -1,8 +1,0 @@
-package team.guin.domain.baseentity
-
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.repository.NoRepositoryBean
-import java.io.Serializable
-
-@NoRepositoryBean
-interface BaseRepository<T : BaseEntity, ID : Serializable> : JpaRepository<T, ID>


### PR DESCRIPTION
기존 Soft Delete로 인하여 생성하였던 BaseRepository를 삭제하였습니다.
- BaseRepository를 삭제함으로써 상속받고있던 인터페이스들 JpaRepository로 변경