### PR TITLE
모집글 상세보기 GET(/team/{id})

### DIFF
--- a/api/src/main/kotlin/team/guin/team/TeamApiController.kt
+++ b/api/src/main/kotlin/team/guin/team/TeamApiController.kt
@@ -16,7 +16,7 @@ import team.guin.team.dto.HashTagDetail
 import team.guin.team.dto.TeamCreateDetail
 import team.guin.team.dto.TeamCreateRequest
 import team.guin.team.dto.TeamDetail
-import team.guin.team.dto.*
+import team.guin.team.dto.TeamListDetail
 
 @RestController
 @RequestMapping("/team")

--- a/api/src/main/kotlin/team/guin/team/TeamApiController.kt
+++ b/api/src/main/kotlin/team/guin/team/TeamApiController.kt
@@ -1,10 +1,11 @@
 package team.guin.team
 
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.guin.common.CommonResponse
 import team.guin.config.annotation.AccountSession
@@ -15,6 +16,7 @@ import team.guin.team.dto.HashTagDetail
 import team.guin.team.dto.TeamCreateDetail
 import team.guin.team.dto.TeamCreateRequest
 import team.guin.team.dto.TeamDetail
+import team.guin.team.dto.*
 
 @RestController
 @RequestMapping("/team")
@@ -38,8 +40,14 @@ class TeamApiController(
     }
 
     @GetMapping
-    fun teamList(@RequestParam subjectType: SubjectType?): CommonResponse<List<TeamDetail>> {
+    fun teamList(@RequestParam subjectType: SubjectType?): CommonResponse<List<TeamListDetail>> {
         val teams = teamApiService.findAllBySubjectType(subjectType)
-        return CommonResponse.okWithDetail(TeamDetail.toDetailList(teams))
+        return CommonResponse.okWithDetail(TeamListDetail.toDetailList(teams))
+    }
+
+    @GetMapping("{teamId}")
+    fun detail(@PathVariable teamId: Long): CommonResponse<TeamDetail> {
+        val team = teamApiService.detail(teamId)
+        return CommonResponse.okWithDetail(TeamDetail.detail(team))
     }
 }

--- a/api/src/main/kotlin/team/guin/team/TeamApiController.kt
+++ b/api/src/main/kotlin/team/guin/team/TeamApiController.kt
@@ -47,7 +47,7 @@ class TeamApiController(
 
     @GetMapping("{teamId}")
     fun detail(@PathVariable teamId: Long): CommonResponse<TeamDetail> {
-        val team = teamApiService.detail(teamId)
+        val team = teamApiService.getTeam(teamId)
         return CommonResponse.okWithDetail(TeamDetail.detail(team))
     }
 }

--- a/api/src/main/kotlin/team/guin/team/TeamApiService.kt
+++ b/api/src/main/kotlin/team/guin/team/TeamApiService.kt
@@ -39,7 +39,11 @@ class TeamApiService(
         return teamApiQueryDslRepository.findAllBySubjectType(subjectType)
     }
 
-    fun findById(id: Long): Team {
-        return teamApiRepository.findById(id).get()
+    fun detail(teamId: Long): Team {
+        return getTeam(teamId)
+    }
+
+    fun getTeam(id: Long): Team {
+        return teamApiRepository.findByIdOrNull(id) ?: throw IllegalStateException("팀이 존재하지 않습니다")
     }
 }

--- a/api/src/main/kotlin/team/guin/team/TeamApiService.kt
+++ b/api/src/main/kotlin/team/guin/team/TeamApiService.kt
@@ -44,6 +44,6 @@ class TeamApiService(
     }
 
     fun getTeam(id: Long): Team {
-        return teamApiRepository.findByIdOrNull(id) ?: throw IllegalStateException("팀이 존재하지 않습니다")
+        return teamApiRepository.findByIdOrNull(id) ?: throw IllegalStateException("팀이 존재하지 않습니다.")
     }
 }

--- a/api/src/main/kotlin/team/guin/team/TeamApiService.kt
+++ b/api/src/main/kotlin/team/guin/team/TeamApiService.kt
@@ -31,7 +31,6 @@ class TeamApiService(
         return teamApiQueryDslRepository.findAllBySubjectType(subjectType)
     }
 
-
     fun getTeam(id: Long): Team {
         return teamApiRepository.findByIdOrNull(id) ?: throw IllegalStateException("팀이 존재하지 않습니다.")
     }

--- a/api/src/main/kotlin/team/guin/team/TeamApiService.kt
+++ b/api/src/main/kotlin/team/guin/team/TeamApiService.kt
@@ -27,21 +27,10 @@ class TeamApiService(
         )
         return teamApiRepository.save(team)
     }
-
-    fun detail(teamId: Long): Team {
-        return findByIdOrNull(teamId)
-    }
-
-    fun findByIdOrNull(id: Long): Team {
-        return teamApiRepository.findByIdOrNull(id) ?: throw IllegalArgumentException("team 없음")
-    }
     fun findAllBySubjectType(subjectType: SubjectType?): List<Team> {
         return teamApiQueryDslRepository.findAllBySubjectType(subjectType)
     }
 
-    fun detail(teamId: Long): Team {
-        return getTeam(teamId)
-    }
 
     fun getTeam(id: Long): Team {
         return teamApiRepository.findByIdOrNull(id) ?: throw IllegalStateException("팀이 존재하지 않습니다.")

--- a/api/src/main/kotlin/team/guin/team/dto/TeamDetail.kt
+++ b/api/src/main/kotlin/team/guin/team/dto/TeamDetail.kt
@@ -2,29 +2,31 @@ package team.guin.team.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import team.guin.domain.team.Team
-import team.guin.domain.team.dto.AttributeDetail
 import team.guin.domain.team.enumeration.SubjectType
+import team.guin.domain.team.enumeration.TagType
 import java.time.LocalDateTime
 
 data class TeamDetail(
-    val leaderName: String,
+    val teamId: Long,
+    val content: String,
     val subject: String,
+    val types: List<TagType>,
     val subjectType: SubjectType,
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    val createdTime: LocalDateTime,
-    val tagTypes: List<AttributeDetail>,
+    val roles: List<TeamRoleDetail>,
+    @JsonFormat(pattern = "yyyy년 MM월 dd일 HH시 mm분 ss초")
+    val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun toDetailList(teams: List<Team>): List<TeamDetail> {
-            return teams.map {
-                TeamDetail(
-                    it.leader.nickname,
-                    it.subject,
-                    it.subjectType,
-                    it.createdAt,
-                    AttributeDetail.create(it.hashTags),
-                )
-            }
+        fun detail(team: Team): TeamDetail {
+            return TeamDetail(
+                teamId = team.id,
+                content = team.content,
+                subject = team.subject,
+                types = team.hashTags.map { it.type },
+                subjectType = team.subjectType,
+                roles = team.roles.map { TeamRoleDetail.create(it) },
+                createdAt = team.createdAt,
+            )
         }
     }
 }

--- a/api/src/main/kotlin/team/guin/team/dto/TeamListDetail.kt
+++ b/api/src/main/kotlin/team/guin/team/dto/TeamListDetail.kt
@@ -1,0 +1,30 @@
+package team.guin.team.dto
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import team.guin.domain.team.Team
+import team.guin.domain.team.dto.AttributeDetail
+import team.guin.domain.team.enumeration.SubjectType
+import java.time.LocalDateTime
+
+data class TeamListDetail(
+    val leaderName: String,
+    val subject: String,
+    val subjectType: SubjectType,
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    val createdTime: LocalDateTime,
+    val tagTypes: List<AttributeDetail>,
+) {
+    companion object {
+        fun toDetailList(teams: List<Team>): List<TeamListDetail> {
+            return teams.map {
+                TeamListDetail(
+                    it.leader.nickname,
+                    it.subject,
+                    it.subjectType,
+                    it.createdAt,
+                    AttributeDetail.create(it.hashTags),
+                )
+            }
+        }
+    }
+}

--- a/api/src/test/kotlin/team/guin/team/TeamApiServiceTest.kt
+++ b/api/src/test/kotlin/team/guin/team/TeamApiServiceTest.kt
@@ -184,12 +184,12 @@ class TeamApiServiceTest(
             val teamId: Long = -1L
 
             // when
-            val result = shouldThrow<IllegalArgumentException> {
+            val result = shouldThrow<IllegalStateException> {
                 teamApiService.detail(teamId)
             }
 
             // then
-            result.message shouldBe "team 없음"
+            result.message shouldBe "팀이 존재하지 않습니다."
         }
     }
 })

--- a/api/src/test/kotlin/team/guin/team/TeamApiServiceTest.kt
+++ b/api/src/test/kotlin/team/guin/team/TeamApiServiceTest.kt
@@ -170,7 +170,7 @@ class TeamApiServiceTest(
             val createTeam = teamApiRepository.createTeam(leader = teamLeader, subjectType = SubjectType.PROJECT)
 
             // when
-            val teamDetail = teamApiService.detail(createTeam.id)
+            val teamDetail = teamApiService.getTeam(createTeam.id)
 
             // then
             teamDetail.content shouldBe createTeam.content
@@ -185,7 +185,7 @@ class TeamApiServiceTest(
 
             // when
             val result = shouldThrow<IllegalStateException> {
-                teamApiService.detail(teamId)
+                teamApiService.getTeam(teamId)
             }
 
             // then


### PR DESCRIPTION
- teamId로 모집글 상세보기 기능 구현하였습니다.
- 테스트코드에서 사용할 팀 생성 확장 함수 추가(모집글 목록 (GET /team) #84 해당 이슈와 충돌 위험 있습니다)